### PR TITLE
Implement diffusion-based weight synthesizer

### DIFF
--- a/diffusion_optimizer.py
+++ b/diffusion_optimizer.py
@@ -1,223 +1,313 @@
-import torch
-import torch.nn as nn
+from __future__ import annotations
+
 import math
-from safetensors.torch import load_file, save_file
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
 
-class MultiHeadSelfAttention(nn.Module):
-    def __init__(self, embed_dim, num_heads):
+import torch
+from safetensors.torch import load_file
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, Dataset
+
+
+TensorDict = Dict[str, Tensor]
+
+
+@dataclass(frozen=True)
+class StateMetadata:
+    key: str
+    shape: torch.Size
+    dtype: torch.dtype
+
+
+def flatten_state_dict(state_dict: TensorDict) -> Tuple[Tensor, List[StateMetadata]]:
+    """Flatten a state dict into a single vector preserving reconstruction metadata."""
+    flat_tensors: List[Tensor] = []
+    metadata: List[StateMetadata] = []
+
+    for key, tensor in state_dict.items():
+        data = tensor.detach().float().reshape(-1)
+        flat_tensors.append(data)
+        metadata.append(StateMetadata(key=key, shape=tensor.shape, dtype=tensor.dtype))
+
+    flat_vector = torch.cat(flat_tensors)
+    return flat_vector, metadata
+
+
+def unflatten_to_state_dict(
+    flat_vector: Tensor, metadata: Sequence[StateMetadata]
+) -> OrderedDict:
+    """Reconstruct a state dict from a flattened vector and associated metadata."""
+    state_dict: OrderedDict[str, Tensor] = OrderedDict()
+    cursor = 0
+
+    for entry in metadata:
+        numel = math.prod(entry.shape)
+        segment = flat_vector[cursor : cursor + numel]
+        cursor += numel
+        tensor = segment.reshape(entry.shape).to(entry.dtype)
+        state_dict[entry.key] = tensor
+
+    if cursor != flat_vector.numel():
+        raise ValueError("Flat vector length does not match provided metadata.")
+
+    return state_dict
+
+
+class ModelZooDataset(Dataset):
+    """Corpus of flattened weight vectors sourced from .safetensors checkpoints."""
+
+    def __init__(self, paths: Iterable[Path | str]):
+        resolved_paths = [Path(p) for p in paths]
+        if not resolved_paths:
+            raise ValueError("Model zoo dataset requires at least one checkpoint path.")
+
+        vectors: List[Tensor] = []
+        self._metadata: List[List[StateMetadata]] = []
+        self._paths: List[Path] = []
+
+        reference_dim: int | None = None
+        for path in resolved_paths:
+            weights = load_file(str(path))
+            flat, metadata = flatten_state_dict(weights)
+            if reference_dim is None:
+                reference_dim = flat.numel()
+            if flat.numel() != reference_dim:
+                raise ValueError(
+                    "All checkpoints must share the same flattened dimensionality."
+                )
+            vectors.append(flat)
+            self._metadata.append(metadata)
+            self._paths.append(path)
+
+        stacked = torch.stack(vectors, dim=0)
+        self._mean = stacked.mean(dim=0)
+        self._std = stacked.std(dim=0, unbiased=False).clamp_min(1e-6)
+        self._normalized = (stacked - self._mean) / self._std
+
+    @property
+    def feature_dim(self) -> int:
+        return self._normalized.shape[1]
+
+    @property
+    def stats(self) -> Tuple[Tensor, Tensor]:
+        return self._mean.clone(), self._std.clone()
+
+    def metadata_for_index(self, index: int) -> Sequence[StateMetadata]:
+        return self._metadata[index]
+
+    def checkpoint_path(self, index: int) -> Path:
+        return self._paths[index]
+
+    def denormalize(self, normalized_vector: Tensor) -> Tensor:
+        return normalized_vector * self._std + self._mean
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return self._normalized.shape[0]
+
+    def __getitem__(self, index: int) -> Tensor:  # type: ignore[override]
+        return self._normalized[index]
+
+
+class DiffusionSchedule:
+    """Cosine diffusion schedule storing precomputed diffusion coefficients."""
+
+    def __init__(self, timesteps: int) -> None:
+        if timesteps <= 0:
+            raise ValueError("timesteps must be positive")
+        self.timesteps = timesteps
+        self._betas = self._cosine_beta_schedule(timesteps)
+        self._alphas = 1.0 - self._betas
+        alphabar = torch.cumprod(self._alphas, dim=0)
+        self._alphabar = torch.cat([torch.ones(1), alphabar])
+        self._sqrt_alphabar = torch.sqrt(self._alphabar)
+        self._sqrt_one_minus_alphabar = torch.sqrt(1.0 - self._alphabar)
+        self._sqrt_recip_alphas = torch.sqrt(1.0 / self._alphas)
+        alphabar_prev = self._alphabar[:-1]
+        alphabar_t = self._alphabar[1:]
+        posterior_variance = self._betas * (1.0 - alphabar_prev) / (1.0 - alphabar_t)
+        self._posterior_variance = posterior_variance.clamp(min=1e-20)
+
+    @staticmethod
+    def _cosine_beta_schedule(timesteps: int) -> Tensor:
+        steps = timesteps + 1
+        x = torch.linspace(0, timesteps, steps)
+        alphas_cumprod = torch.cos(((x / timesteps) + 0.008) / 1.008 * math.pi / 2) ** 2
+        alphas_cumprod = alphas_cumprod / alphas_cumprod[0]
+        betas = 1 - (alphas_cumprod[1:] / alphas_cumprod[:-1])
+        return betas.clamp(0.0001, 0.9999)
+
+    @property
+    def betas(self) -> Tensor:
+        return self._betas.clone()
+
+    @property
+    def sqrt_alphabar(self) -> Tensor:
+        return self._sqrt_alphabar.clone()
+
+    @property
+    def sqrt_one_minus_alphabar(self) -> Tensor:
+        return self._sqrt_one_minus_alphabar.clone()
+
+    @property
+    def sqrt_recip_alphas(self) -> Tensor:
+        return self._sqrt_recip_alphas.clone()
+
+    @property
+    def posterior_variance(self) -> Tensor:
+        return self._posterior_variance.clone()
+
+
+class WeightDiffusionMLP(nn.Module):
+    """Architecture-agnostic noise predictor operating on flattened weight vectors."""
+
+    def __init__(self, parameter_dim: int, bottleneck_dim: int = 512) -> None:
         super().__init__()
-        self.embed_dim = embed_dim
-        self.num_heads = num_heads
-        self.head_dim = embed_dim // num_heads
+        self.parameter_dim = parameter_dim
+        self.fc1 = nn.Linear(parameter_dim + 1, bottleneck_dim)
+        self.fc2 = nn.Linear(bottleneck_dim, bottleneck_dim)
+        self.fc3 = nn.Linear(bottleneck_dim, parameter_dim)
+        self.activation = nn.SiLU()
 
-        assert (
-            self.head_dim * self.num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
-
-        self.values = nn.Linear(self.head_dim, self.head_dim, bias=False)
-        self.keys = nn.Linear(self.head_dim, self.head_dim, bias=False)
-        self.queries = nn.Linear(self.head_dim, self.head_dim, bias=False)
-        self.fc_out = nn.Linear(self.num_heads * self.head_dim, embed_dim)
-
-    def forward(self, values, keys, query, mask):
-        N = query.shape[0]
-        value_len, key_len, query_len = values.shape[1], keys.shape[1], query.shape[1]
-
-        # Split the embedding into self.num_heads different pieces
-        values = values.reshape(N, value_len, self.num_heads, self.head_dim)
-        keys = keys.reshape(N, key_len, self.num_heads, self.head_dim)
-        queries = query.reshape(N, query_len, self.num_heads, self.head_dim)
-
-        values = self.values(values)
-        keys = self.keys(keys)
-        queries = self.queries(queries)
-
-        # Einsum does matrix multiplication for query*keys for each training example
-        # with every other training example, don't be confused by einsum
-        # it's just how I like doing matrix multiplication
-        attention = torch.einsum("nqhd,nkhd->nhqk", [queries, keys])
-
-        if mask is not None:
-            attention = attention.masked_fill(mask == 0, float("-1e20"))
-
-        attention = torch.softmax(attention / (self.embed_dim ** (1 / 2)), dim=3)
-
-        out = torch.einsum("nhql,nlhd->nqhd", [attention, values]).reshape(
-            N, query_len, self.num_heads * self.head_dim
-        )
-
-        out = self.fc_out(out)
-        return out
+    def forward(self, x: Tensor, timesteps: Tensor) -> Tensor:  # type: ignore[override]
+        if timesteps.ndim == 1:
+            t = timesteps.unsqueeze(1)
+        elif timesteps.ndim == 2 and timesteps.shape[1] == 1:
+            t = timesteps
+        else:
+            raise ValueError("timesteps tensor must be of shape (batch,) or (batch, 1)")
+        if x.shape[0] != t.shape[0]:
+            raise ValueError("Mismatch between batch size of inputs and timesteps")
+        concatenated = torch.cat([x, t], dim=1)
+        h = self.activation(self.fc1(concatenated))
+        h = self.activation(self.fc2(h))
+        return self.fc3(h)
 
 
-class TransformerBlock(nn.Module):
-    def __init__(self, embed_dim, num_heads, ff_hidden_dim, dropout):
-        super().__init__()
-        self.attention = MultiHeadSelfAttention(embed_dim, num_heads)
-        self.norm1 = nn.LayerNorm(embed_dim)
-        self.norm2 = nn.LayerNorm(embed_dim)
-
-        self.feed_forward = nn.Sequential(
-            nn.Linear(embed_dim, ff_hidden_dim),
-            nn.ReLU(),
-            nn.Linear(ff_hidden_dim, embed_dim),
-        )
-
-        self.dropout = nn.Dropout(dropout)
-
-    def forward(self, value, key, query, mask):
-        attention = self.attention(value, key, query, mask)
-
-        # Add skip connection, run through normalization and finally dropout
-        x = self.dropout(self.norm1(attention + query))
-        forward = self.feed_forward(x)
-        out = self.dropout(self.norm2(forward + x))
-        return out
+def _prepare_dataloader(dataset: ModelZooDataset, batch_size: int) -> DataLoader:
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=len(dataset) > 1)
 
 
-class DiffusionOptimizer(nn.Module):
-    def __init__(
-        self,
-        embed_dim,
-        num_heads,
-        num_layers,
-        ff_hidden_dim,
-        dropout,
-        max_timesteps=1000,
-    ):
-        super().__init__()
-        self.embed_dim = embed_dim
-        self.max_timesteps = max_timesteps
+def train_synthesizer(
+    model: WeightDiffusionMLP,
+    dataset: ModelZooDataset,
+    schedule: DiffusionSchedule,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    device: torch.device | str = "cpu",
+) -> List[float]:
+    if epochs <= 0:
+        raise ValueError("epochs must be positive")
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if lr <= 0:
+        raise ValueError("learning rate must be positive")
 
-        self.layers = nn.ModuleList(
-            [
-                TransformerBlock(embed_dim, num_heads, ff_hidden_dim, dropout)
-                for _ in range(num_layers)
-            ]
-        )
-        self.dropout = nn.Dropout(dropout)
-        self.projection_layers = nn.ModuleDict()
-        self.unprojection_layers = nn.ModuleDict()
+    device = torch.device(device)
+    model.to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr)
+    losses: List[float] = []
+    dataloader = _prepare_dataloader(dataset, batch_size)
 
-    def _get_projection_key(self, shape):
-        return str(list(shape))
+    for _ in range(epochs):
+        for batch in dataloader:
+            x0 = batch.to(device)
+            batch_size = x0.shape[0]
+            t = torch.randint(0, schedule.timesteps + 1, (batch_size,), device=device)
+            sqrt_alphabar = schedule.sqrt_alphabar.to(device)[t]
+            sqrt_one_minus = schedule.sqrt_one_minus_alphabar.to(device)[t]
+            noise = torch.randn_like(x0)
+            xt = sqrt_alphabar.unsqueeze(1) * x0 + sqrt_one_minus.unsqueeze(1) * noise
+            t_normalized = t.float() / schedule.timesteps
+            predicted_noise = model(xt, t_normalized)
+            loss = nn.functional.mse_loss(predicted_noise, noise)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            losses.append(loss.item())
 
-    def _ensure_projection_layers(self, key, tensor):
-        if key not in self.projection_layers:
-            num_features = tensor.numel()
-            self.projection_layers[key] = nn.Linear(num_features, self.embed_dim)
-            self.unprojection_layers[key] = nn.Linear(self.embed_dim, num_features)
-
-    def forward(self, weights_dict, t):
-        device = next(self.parameters()).device
-        vectors = []
-        shapes = {}
-        keys_order = []
-
-        for key, tensor in weights_dict.items():
-            shape_key = self._get_projection_key(tensor.shape)
-            self._ensure_projection_layers(shape_key, tensor)
-
-            tensor_in = tensor.to(device).flatten()
-            vectors.append(self.projection_layers[shape_key](tensor_in))
-
-            shapes[key] = tensor.shape
-            keys_order.append(key)
-
-        # Create a sequence tensor
-        sequence = torch.stack(vectors, dim=0).unsqueeze(0) # (1, L, embed_dim)
-
-        # Add positional embeddings
-        positional_embeddings = self.get_positional_embedding(len(keys_order), self.embed_dim).to(device)
-        sequence += positional_embeddings
-
-        # Add timestep embedding
-        timestep_embedding = self.get_timestep_embedding(t, self.embed_dim).to(device)
-        sequence += timestep_embedding.unsqueeze(1)
-
-        # Transformer blocks
-        for layer in self.layers:
-            sequence = layer(sequence, sequence, sequence, mask=None)
-
-        # Denoise and reconstruct
-        denoised_weights = {}
-        for i, key in enumerate(keys_order):
-            shape = shapes[key]
-            shape_key = self._get_projection_key(shape)
-            output_vector = sequence.squeeze(0)[i]
-
-            reconstructed_tensor = self.unprojection_layers[shape_key](output_vector)
-            denoised_weights[key] = reconstructed_tensor.reshape(shape)
-
-        return denoised_weights
-
-    def get_positional_embedding(self, seq_len, embed_dim):
-        position = torch.arange(seq_len, dtype=torch.float32).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, embed_dim, 2).float() * -(math.log(10000.0) / embed_dim))
-        pos_emb = torch.zeros(seq_len, embed_dim)
-        pos_emb[:, 0::2] = torch.sin(position * div_term)
-        pos_emb[:, 1::2] = torch.cos(position * div_term)
-        return pos_emb.unsqueeze(0)
-
-    def get_timestep_embedding(self, t, embed_dim):
-        half_dim = embed_dim // 2
-        emb = math.log(10000) / (half_dim - 1)
-        emb = torch.exp(torch.arange(half_dim, dtype=torch.float32) * -emb)
-        emb = t.float().unsqueeze(1) * emb.unsqueeze(0)
-        emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=1)
-        if embed_dim % 2 == 1:
-            emb = torch.nn.functional.pad(emb, (0, 1))
-        return emb
+    return losses
 
 
-if __name__ == "__main__":
-    # 1. Define a toy model and save its weights to a .safetensors file
-    class ToyModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv1 = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1)
-            self.relu = nn.ReLU()
-            self.fc1 = nn.Linear(16 * 28 * 28, 10)
+def generate_weight_vectors(
+    model: WeightDiffusionMLP,
+    schedule: DiffusionSchedule,
+    mean: Tensor,
+    std: Tensor,
+    metadata: Sequence[StateMetadata],
+    num_samples: int,
+    device: torch.device | str = "cpu",
+) -> List[OrderedDict]:
+    if num_samples <= 0:
+        raise ValueError("num_samples must be positive")
 
-        def forward(self, x):
-            x = self.conv1(x)
-            x = self.relu(x)
-            x = x.view(x.size(0), -1)
-            x = self.fc1(x)
-            return x
+    device = torch.device(device)
+    model = model.to(device)
+    model.eval()
+    parameter_dim = mean.numel()
+    mean = mean.to(device)
+    std = std.to(device)
 
-    toy_model = ToyModel()
-    weights = toy_model.state_dict()
+    samples: List[OrderedDict] = []
+    with torch.no_grad():
+        xt = torch.randn(num_samples, parameter_dim, device=device)
+        for timestep in range(schedule.timesteps, 0, -1):
+            t_tensor = torch.full((num_samples,), timestep, device=device)
+            t_normalized = t_tensor.float() / schedule.timesteps
+            predicted_noise = model(xt, t_normalized)
+            beta_t = schedule.betas.to(device)[timestep - 1]
+            sqrt_recip_alpha = schedule.sqrt_recip_alphas.to(device)[timestep - 1]
+            sqrt_one_minus = schedule.sqrt_one_minus_alphabar.to(device)[timestep]
+            model_mean = (
+                sqrt_recip_alpha * (xt - beta_t / sqrt_one_minus * predicted_noise)
+            )
+            if timestep > 1:
+                noise = torch.randn_like(xt)
+                variance = schedule.posterior_variance.to(device)[timestep - 1]
+                xt = model_mean + torch.sqrt(variance) * noise
+            else:
+                xt = model_mean
 
-    # Save to a temporary file
-    temp_weights_file = "temp_weights.safetensors"
-    save_file(weights, temp_weights_file)
+        x0 = xt * std.unsqueeze(0) + mean.unsqueeze(0)
+        for vector in x0:
+            samples.append(unflatten_to_state_dict(vector.cpu(), metadata))
 
-    # 2. Initialize the Diffusion Optimizer
-    optimizer = DiffusionOptimizer(
-        embed_dim=128,
-        num_heads=8,
-        num_layers=6,
-        ff_hidden_dim=256,
-        dropout=0.1,
-    )
+    return samples
 
-    # 3. Load the weights from the .safetensors file
-    loaded_weights = load_file(temp_weights_file)
 
-    # 4. Create a dummy timestep
-    t = torch.randint(0, 1000, (1,))
+def compute_weight_statistics(state_dict: TensorDict) -> Dict[str, float]:
+    flat, _ = flatten_state_dict(state_dict)
+    mean = flat.mean().item()
+    variance = flat.var(unbiased=False).item()
+    std = math.sqrt(variance)
+    centered = (flat - flat.mean()) / (std + 1e-8)
+    kurtosis = torch.mean(centered ** 4).item()
+    return {"mean": mean, "variance": variance, "std": std, "kurtosis": kurtosis}
 
-    # 5. Get the denoised weights
-    denoised_weights = optimizer(loaded_weights, t)
 
-    # 6. Check that the output shapes match the input shapes
-    for key in loaded_weights.keys():
-        assert loaded_weights[key].shape == denoised_weights[key].shape, \
-            f"Shape mismatch for weight {key}: original {loaded_weights[key].shape}, denoised {denoised_weights[key].shape}"
+def compute_spectral_properties(state_dict: TensorDict) -> Dict[str, Tensor]:
+    spectra: Dict[str, Tensor] = {}
+    for key, tensor in state_dict.items():
+        if tensor.ndim < 2:
+            continue
+        matrix = tensor.reshape(tensor.shape[0], -1).float()
+        cov = matrix @ matrix.transpose(0, 1) / matrix.shape[1]
+        eigenvalues = torch.linalg.eigvalsh(cov.cpu())
+        spectra[key] = eigenvalues
+    return spectra
 
-    print("Diffusion Optimizer ran successfully!")
 
-    # 7. Clean up the temporary file
-    import os
-    os.remove(temp_weights_file)
+__all__ = [
+    "ModelZooDataset",
+    "DiffusionSchedule",
+    "WeightDiffusionMLP",
+    "flatten_state_dict",
+    "unflatten_to_state_dict",
+    "train_synthesizer",
+    "generate_weight_vectors",
+    "compute_weight_statistics",
+    "compute_spectral_properties",
+]

--- a/tests/test_diffusion_optimizer.py
+++ b/tests/test_diffusion_optimizer.py
@@ -1,0 +1,99 @@
+import math
+from pathlib import Path
+from typing import List
+
+import torch
+from safetensors.torch import save_file
+
+from diffusion_optimizer import (
+    DiffusionSchedule,
+    ModelZooDataset,
+    WeightDiffusionMLP,
+    compute_spectral_properties,
+    compute_weight_statistics,
+    flatten_state_dict,
+    generate_weight_vectors,
+    train_synthesizer,
+    unflatten_to_state_dict,
+)
+
+
+def _create_toy_state_dict(seed: int = 0) -> dict:
+    torch.manual_seed(seed)
+    model = torch.nn.Sequential(
+        torch.nn.Linear(8, 16),
+        torch.nn.ReLU(),
+        torch.nn.Linear(16, 4),
+    )
+    return model.state_dict()
+
+
+def _write_corpus(tmp_path: Path, count: int) -> List[Path]:
+    paths: List[Path] = []
+    for idx in range(count):
+        state_dict = _create_toy_state_dict(seed=idx)
+        path = tmp_path / f"model_{idx}.safetensors"
+        save_file(state_dict, str(path))
+        paths.append(path)
+    return paths
+
+
+def test_flatten_and_unflatten_roundtrip():
+    state_dict = _create_toy_state_dict()
+    flat, metadata = flatten_state_dict(state_dict)
+    reconstructed = unflatten_to_state_dict(flat, metadata)
+    assert set(reconstructed.keys()) == set(state_dict.keys())
+    for key, original in state_dict.items():
+        restored = reconstructed[key]
+        assert restored.shape == original.shape
+        assert restored.dtype == original.dtype
+
+
+def test_dataset_normalization(tmp_path):
+    paths = _write_corpus(tmp_path, count=3)
+    dataset = ModelZooDataset(paths)
+    stacked = torch.stack([dataset[idx] for idx in range(len(dataset))])
+    mean = stacked.mean().item()
+    std = stacked.std(unbiased=False).item()
+    assert abs(mean) < 1e-5
+    assert math.isclose(std, 1.0, rel_tol=5e-3)
+
+
+def test_training_and_generation(tmp_path):
+    paths = _write_corpus(tmp_path, count=4)
+    dataset = ModelZooDataset(paths)
+    schedule = DiffusionSchedule(timesteps=10)
+    model = WeightDiffusionMLP(parameter_dim=dataset.feature_dim)
+
+    losses = train_synthesizer(
+        model,
+        dataset,
+        schedule,
+        epochs=1,
+        batch_size=2,
+        lr=1e-3,
+    )
+    assert losses, "Training did not record any losses"
+
+    mean, std = dataset.stats
+    metadata = dataset.metadata_for_index(0)
+    generated = generate_weight_vectors(
+        model,
+        schedule,
+        mean,
+        std,
+        metadata,
+        num_samples=1,
+    )
+    assert len(generated) == 1
+    template = unflatten_to_state_dict(dataset[0] * std + mean, metadata)
+    for key, tensor in generated[0].items():
+        assert tensor.shape == template[key].shape
+        assert tensor.dtype == template[key].dtype
+
+    stats = compute_weight_statistics(generated[0])
+    assert {"mean", "variance", "std", "kurtosis"}.issubset(stats.keys())
+
+    spectra = compute_spectral_properties(generated[0])
+    for values in spectra.values():
+        assert values.min().item() >= -1e-5


### PR DESCRIPTION
## Summary
- replace the prior transformer-based optimizer with a diffusion synthesizer operating on flattened checkpoint vectors
- add a cosine diffusion schedule, MLP noise predictor, training loop, sampling routine, and corpus utilities for static model zoos
- provide evaluation helpers for statistical and spectral analysis plus end-to-end unit tests covering normalization, training, and generation

## Testing
- `pytest` *(fails: missing torch dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d14263f3648325ad38cacdb0fd3320