### PR TITLE
Implement static corpus diffusion synthesizer

### DIFF
--- a/diffusion_optimizer.py
+++ b/diffusion_optimizer.py
@@ -1,223 +1,254 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
 import torch
 import torch.nn as nn
-import math
-from safetensors.torch import load_file, save_file
+from safetensors.torch import load_file
 
-class MultiHeadSelfAttention(nn.Module):
-    def __init__(self, embed_dim, num_heads):
+TensorDict = Dict[str, torch.Tensor]
+
+
+@dataclass(frozen=True)
+class TensorInfo:
+    key: str
+    shape: torch.Size
+    dtype: torch.dtype
+    numel: int
+
+
+def flatten_state_dict(state_dict: TensorDict) -> Tuple[torch.Tensor, List[TensorInfo]]:
+    if not state_dict:
+        raise ValueError("state_dict must not be empty")
+
+    flat_tensors: List[torch.Tensor] = []
+    metadata: List[TensorInfo] = []
+
+    for key, tensor in state_dict.items():
+        if not torch.is_floating_point(tensor):
+            raise TypeError(f"Tensor '{key}' must be floating point")
+
+        flattened = tensor.detach().reshape(-1).to(torch.float32)
+        flat_tensors.append(flattened)
+        metadata.append(TensorInfo(key=key, shape=tensor.shape, dtype=tensor.dtype, numel=tensor.numel()))
+
+    return torch.cat(flat_tensors, dim=0), metadata
+
+
+def unflatten_to_state_dict(flat_vector: torch.Tensor, metadata: Sequence[TensorInfo]) -> TensorDict:
+    if flat_vector.ndim != 1:
+        raise ValueError("flat_vector must be one-dimensional")
+
+    total = sum(info.numel for info in metadata)
+    if flat_vector.numel() != total:
+        raise ValueError("flat_vector length does not match metadata")
+
+    state_dict: TensorDict = {}
+    offset = 0
+    for info in metadata:
+        chunk = flat_vector[offset : offset + info.numel]
+        state_dict[info.key] = chunk.reshape(info.shape).to(info.dtype)
+        offset += info.numel
+
+    return state_dict
+
+
+class ModelZooCorpus(torch.utils.data.Dataset):
+    def __init__(self, weight_files: Sequence[Path | str]):
+        if not weight_files:
+            raise ValueError("weight_files must not be empty")
+
+        self._paths = [Path(path) for path in weight_files]
+        self._vectors: List[torch.Tensor] = []
+        self.metadata: List[List[TensorInfo]] = []
+
+        for path in self._paths:
+            state_dict = load_file(str(path))
+            flat, info = flatten_state_dict(state_dict)
+            self._vectors.append(flat)
+            self.metadata.append(info)
+
+        lengths = {vec.numel() for vec in self._vectors}
+        if len(lengths) != 1:
+            raise ValueError("All weight vectors must share the same dimensionality")
+
+        self.vector_dim = lengths.pop()
+        stacked = torch.stack(self._vectors, dim=0)
+        self.mean = stacked.mean(dim=0)
+        self.std = stacked.std(dim=0, unbiased=False)
+        self.std = torch.where(self.std < 1e-6, torch.ones_like(self.std), self.std)
+        self._vectors = stacked
+
+    def __len__(self) -> int:
+        return self._vectors.shape[0]
+
+    def __getitem__(self, index: int) -> Tuple[torch.Tensor, List[TensorInfo]]:
+        normalized = (self._vectors[index] - self.mean) / self.std
+        return normalized.clone(), self.metadata[index]
+
+    @property
+    def vectors(self) -> torch.Tensor:
+        return self._vectors
+
+    def denormalize(self, normalized_vector: torch.Tensor) -> torch.Tensor:
+        if normalized_vector.shape[-1] != self.vector_dim:
+            raise ValueError("normalized_vector has incorrect dimensionality")
+
+        mean = self.mean.to(normalized_vector.device)
+        std = self.std.to(normalized_vector.device)
+        return normalized_vector * std + mean
+
+
+class CosineSchedule:
+    def __init__(self, timesteps: int, s: float = 0.008):
+        if timesteps <= 0:
+            raise ValueError("timesteps must be positive")
+
+        steps = torch.arange(timesteps + 1, dtype=torch.float64)
+        alphas_cumprod = torch.cos(((steps / timesteps) + s) / (1 + s) * math.pi / 2) ** 2
+        alphas_cumprod = alphas_cumprod / alphas_cumprod[0]
+
+        betas = 1 - (alphas_cumprod[1:] / alphas_cumprod[:-1])
+        betas = betas.clamp(1e-7, 0.999)
+
+        self.betas = betas.to(dtype=torch.float32)
+        self.alphas = (1.0 - self.betas).to(dtype=torch.float32)
+        self.alpha_bar = torch.cumprod(self.alphas, dim=0)
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, dim: int, dropout: float = 0.0):
         super().__init__()
-        self.embed_dim = embed_dim
-        self.num_heads = num_heads
-        self.head_dim = embed_dim // num_heads
-
-        assert (
-            self.head_dim * self.num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
-
-        self.values = nn.Linear(self.head_dim, self.head_dim, bias=False)
-        self.keys = nn.Linear(self.head_dim, self.head_dim, bias=False)
-        self.queries = nn.Linear(self.head_dim, self.head_dim, bias=False)
-        self.fc_out = nn.Linear(self.num_heads * self.head_dim, embed_dim)
-
-    def forward(self, values, keys, query, mask):
-        N = query.shape[0]
-        value_len, key_len, query_len = values.shape[1], keys.shape[1], query.shape[1]
-
-        # Split the embedding into self.num_heads different pieces
-        values = values.reshape(N, value_len, self.num_heads, self.head_dim)
-        keys = keys.reshape(N, key_len, self.num_heads, self.head_dim)
-        queries = query.reshape(N, query_len, self.num_heads, self.head_dim)
-
-        values = self.values(values)
-        keys = self.keys(keys)
-        queries = self.queries(queries)
-
-        # Einsum does matrix multiplication for query*keys for each training example
-        # with every other training example, don't be confused by einsum
-        # it's just how I like doing matrix multiplication
-        attention = torch.einsum("nqhd,nkhd->nhqk", [queries, keys])
-
-        if mask is not None:
-            attention = attention.masked_fill(mask == 0, float("-1e20"))
-
-        attention = torch.softmax(attention / (self.embed_dim ** (1 / 2)), dim=3)
-
-        out = torch.einsum("nhql,nlhd->nqhd", [attention, values]).reshape(
-            N, query_len, self.num_heads * self.head_dim
-        )
-
-        out = self.fc_out(out)
-        return out
-
-
-class TransformerBlock(nn.Module):
-    def __init__(self, embed_dim, num_heads, ff_hidden_dim, dropout):
-        super().__init__()
-        self.attention = MultiHeadSelfAttention(embed_dim, num_heads)
-        self.norm1 = nn.LayerNorm(embed_dim)
-        self.norm2 = nn.LayerNorm(embed_dim)
-
-        self.feed_forward = nn.Sequential(
-            nn.Linear(embed_dim, ff_hidden_dim),
-            nn.ReLU(),
-            nn.Linear(ff_hidden_dim, embed_dim),
-        )
-
+        self.norm = nn.LayerNorm(dim)
+        self.linear1 = nn.Linear(dim, dim)
+        self.activation = nn.SiLU()
         self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim, dim)
 
-    def forward(self, value, key, query, mask):
-        attention = self.attention(value, key, query, mask)
-
-        # Add skip connection, run through normalization and finally dropout
-        x = self.dropout(self.norm1(attention + query))
-        forward = self.feed_forward(x)
-        out = self.dropout(self.norm2(forward + x))
-        return out
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        hidden = self.norm(inputs)
+        hidden = self.activation(self.linear1(hidden))
+        hidden = self.dropout(hidden)
+        hidden = self.linear2(hidden)
+        return inputs + hidden
 
 
-class DiffusionOptimizer(nn.Module):
-    def __init__(
-        self,
-        embed_dim,
-        num_heads,
-        num_layers,
-        ff_hidden_dim,
-        dropout,
-        max_timesteps=1000,
-    ):
+class MLPWeightSynthesizer(nn.Module):
+    def __init__(self, vector_dim: int, timesteps: int, dropout: float = 0.1, num_residual_layers: int = 3):
         super().__init__()
-        self.embed_dim = embed_dim
-        self.max_timesteps = max_timesteps
-
-        self.layers = nn.ModuleList(
-            [
-                TransformerBlock(embed_dim, num_heads, ff_hidden_dim, dropout)
-                for _ in range(num_layers)
-            ]
+        self.vector_dim = vector_dim
+        self.timesteps = timesteps
+        self.input_layer = nn.Linear(vector_dim + 1, 512)
+        self.activation = nn.SiLU()
+        self.residual_layers = nn.ModuleList(
+            ResidualBlock(512, dropout=dropout) for _ in range(num_residual_layers)
         )
-        self.dropout = nn.Dropout(dropout)
-        self.projection_layers = nn.ModuleDict()
-        self.unprojection_layers = nn.ModuleDict()
+        self.final_norm = nn.LayerNorm(512)
+        self.output_layer = nn.Linear(512, vector_dim)
 
-    def _get_projection_key(self, shape):
-        return str(list(shape))
+    def forward(self, inputs: torch.Tensor, timesteps: torch.Tensor) -> torch.Tensor:
+        if inputs.ndim != 2 or inputs.shape[1] != self.vector_dim:
+            raise ValueError("inputs must be of shape (batch, vector_dim)")
 
-    def _ensure_projection_layers(self, key, tensor):
-        if key not in self.projection_layers:
-            num_features = tensor.numel()
-            self.projection_layers[key] = nn.Linear(num_features, self.embed_dim)
-            self.unprojection_layers[key] = nn.Linear(self.embed_dim, num_features)
+        if timesteps.ndim != 1 or timesteps.shape[0] != inputs.shape[0]:
+            raise ValueError("timesteps must be one-dimensional with length batch size")
 
-    def forward(self, weights_dict, t):
-        device = next(self.parameters()).device
-        vectors = []
-        shapes = {}
-        keys_order = []
+        time_feature = timesteps.to(inputs.dtype).unsqueeze(1)
+        if self.timesteps > 1:
+            time_feature = time_feature / float(self.timesteps - 1)
 
-        for key, tensor in weights_dict.items():
-            shape_key = self._get_projection_key(tensor.shape)
-            self._ensure_projection_layers(shape_key, tensor)
-
-            tensor_in = tensor.to(device).flatten()
-            vectors.append(self.projection_layers[shape_key](tensor_in))
-
-            shapes[key] = tensor.shape
-            keys_order.append(key)
-
-        # Create a sequence tensor
-        sequence = torch.stack(vectors, dim=0).unsqueeze(0) # (1, L, embed_dim)
-
-        # Add positional embeddings
-        positional_embeddings = self.get_positional_embedding(len(keys_order), self.embed_dim).to(device)
-        sequence += positional_embeddings
-
-        # Add timestep embedding
-        timestep_embedding = self.get_timestep_embedding(t, self.embed_dim).to(device)
-        sequence += timestep_embedding.unsqueeze(1)
-
-        # Transformer blocks
-        for layer in self.layers:
-            sequence = layer(sequence, sequence, sequence, mask=None)
-
-        # Denoise and reconstruct
-        denoised_weights = {}
-        for i, key in enumerate(keys_order):
-            shape = shapes[key]
-            shape_key = self._get_projection_key(shape)
-            output_vector = sequence.squeeze(0)[i]
-
-            reconstructed_tensor = self.unprojection_layers[shape_key](output_vector)
-            denoised_weights[key] = reconstructed_tensor.reshape(shape)
-
-        return denoised_weights
-
-    def get_positional_embedding(self, seq_len, embed_dim):
-        position = torch.arange(seq_len, dtype=torch.float32).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, embed_dim, 2).float() * -(math.log(10000.0) / embed_dim))
-        pos_emb = torch.zeros(seq_len, embed_dim)
-        pos_emb[:, 0::2] = torch.sin(position * div_term)
-        pos_emb[:, 1::2] = torch.cos(position * div_term)
-        return pos_emb.unsqueeze(0)
-
-    def get_timestep_embedding(self, t, embed_dim):
-        half_dim = embed_dim // 2
-        emb = math.log(10000) / (half_dim - 1)
-        emb = torch.exp(torch.arange(half_dim, dtype=torch.float32) * -emb)
-        emb = t.float().unsqueeze(1) * emb.unsqueeze(0)
-        emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=1)
-        if embed_dim % 2 == 1:
-            emb = torch.nn.functional.pad(emb, (0, 1))
-        return emb
+        features = torch.cat([inputs, time_feature], dim=1)
+        hidden = self.activation(self.input_layer(features))
+        for layer in self.residual_layers:
+            hidden = layer(hidden)
+        hidden = self.activation(self.final_norm(hidden))
+        return self.output_layer(hidden)
 
 
-if __name__ == "__main__":
-    # 1. Define a toy model and save its weights to a .safetensors file
-    class ToyModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv1 = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1)
-            self.relu = nn.ReLU()
-            self.fc1 = nn.Linear(16 * 28 * 28, 10)
+class DiffusionSynthesizer(nn.Module):
+    def __init__(self, vector_dim: int, timesteps: int = 1000, dropout: float = 0.1, residual_layers: int = 3):
+        super().__init__()
+        self.vector_dim = vector_dim
+        self.timesteps = timesteps
+        self.network = MLPWeightSynthesizer(vector_dim, timesteps, dropout=dropout, num_residual_layers=residual_layers)
 
-        def forward(self, x):
-            x = self.conv1(x)
-            x = self.relu(x)
-            x = x.view(x.size(0), -1)
-            x = self.fc1(x)
-            return x
+        schedule = CosineSchedule(timesteps)
+        self.register_buffer("betas", schedule.betas)
+        self.register_buffer("alphas", schedule.alphas)
+        self.register_buffer("alpha_bar", schedule.alpha_bar)
+        self.register_buffer("sqrt_recip_alpha", torch.sqrt(1.0 / schedule.alphas))
+        self.register_buffer("sqrt_one_minus_alpha_bar", torch.sqrt(1.0 - schedule.alpha_bar))
+        self.register_buffer("sqrt_betas", torch.sqrt(schedule.betas))
 
-    toy_model = ToyModel()
-    weights = toy_model.state_dict()
+    def forward(self, inputs: torch.Tensor, timesteps: torch.Tensor) -> torch.Tensor:
+        return self.network(inputs, timesteps)
 
-    # Save to a temporary file
-    temp_weights_file = "temp_weights.safetensors"
-    save_file(weights, temp_weights_file)
+    def _extract(self, buffer: torch.Tensor, timesteps: torch.Tensor) -> torch.Tensor:
+        values = buffer.index_select(0, timesteps.detach().cpu()).to(timesteps.device)
+        return values.unsqueeze(-1)
 
-    # 2. Initialize the Diffusion Optimizer
-    optimizer = DiffusionOptimizer(
-        embed_dim=128,
-        num_heads=8,
-        num_layers=6,
-        ff_hidden_dim=256,
-        dropout=0.1,
-    )
+    def _random_normal(
+        self, shape: Tuple[int, ...], device: torch.device, dtype: torch.dtype, generator: torch.Generator | None
+    ) -> torch.Tensor:
+        if generator is None:
+            return torch.randn(shape, device=device, dtype=dtype)
+        return torch.randn(shape, device=device, dtype=dtype, generator=generator)
 
-    # 3. Load the weights from the .safetensors file
-    loaded_weights = load_file(temp_weights_file)
+    def predict(self, noisy_weights: torch.Tensor, timesteps: torch.Tensor) -> torch.Tensor:
+        return self.forward(noisy_weights, timesteps)
 
-    # 4. Create a dummy timestep
-    t = torch.randint(0, 1000, (1,))
+    def compute_loss(self, clean_weights: torch.Tensor) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        if clean_weights.ndim != 2 or clean_weights.shape[1] != self.vector_dim:
+            raise ValueError("clean_weights must be of shape (batch, vector_dim)")
 
-    # 5. Get the denoised weights
-    denoised_weights = optimizer(loaded_weights, t)
+        batch_size = clean_weights.shape[0]
+        device = clean_weights.device
+        timesteps = torch.randint(0, self.timesteps, (batch_size,), device=device)
+        noise = torch.randn_like(clean_weights)
 
-    # 6. Check that the output shapes match the input shapes
-    for key in loaded_weights.keys():
-        assert loaded_weights[key].shape == denoised_weights[key].shape, \
-            f"Shape mismatch for weight {key}: original {loaded_weights[key].shape}, denoised {denoised_weights[key].shape}"
+        sqrt_alpha_bar_t = torch.sqrt(self._extract(self.alpha_bar, timesteps))
+        sqrt_one_minus_alpha_bar_t = torch.clamp(
+            self._extract(self.sqrt_one_minus_alpha_bar, timesteps), min=1e-7
+        )
+        noisy_weights = sqrt_alpha_bar_t * clean_weights + sqrt_one_minus_alpha_bar_t * noise
+        predicted_noise = self.predict(noisy_weights, timesteps)
+        loss = torch.mean((noise - predicted_noise) ** 2)
 
-    print("Diffusion Optimizer ran successfully!")
+        return loss, {
+            "timesteps": timesteps,
+            "noise": noise,
+            "noisy_weights": noisy_weights,
+            "predicted_noise": predicted_noise,
+        }
 
-    # 7. Clean up the temporary file
-    import os
-    os.remove(temp_weights_file)
+    @torch.no_grad()
+    def sample(self, num_samples: int, device: torch.device | None = None, generator: torch.Generator | None = None) -> torch.Tensor:
+        if num_samples <= 0:
+            raise ValueError("num_samples must be positive")
+
+        if device is None:
+            device = self.betas.device
+
+        samples = self._random_normal((num_samples, self.vector_dim), device, torch.float32, generator)
+
+        for step in reversed(range(self.timesteps)):
+            timesteps = torch.full((num_samples,), step, device=device, dtype=torch.long)
+            predicted_noise = self.predict(samples, timesteps)
+
+            sqrt_recip_alpha_t = self._extract(self.sqrt_recip_alpha, timesteps)
+            sqrt_one_minus_alpha_bar_t = torch.clamp(
+                self._extract(self.sqrt_one_minus_alpha_bar, timesteps), min=1e-7
+            )
+            beta_t = self._extract(self.betas, timesteps)
+
+            samples = sqrt_recip_alpha_t * (samples - (beta_t / sqrt_one_minus_alpha_bar_t) * predicted_noise)
+
+            if step > 0:
+                noise = self._random_normal(samples.shape, device, samples.dtype, generator)
+                sigma_t = self._extract(self.sqrt_betas, timesteps)
+                samples = samples + sigma_t * noise
+
+        return samples

--- a/tests/test_diffusion_optimizer.py
+++ b/tests/test_diffusion_optimizer.py
@@ -1,0 +1,74 @@
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+
+from diffusion_optimizer import (
+    DiffusionSynthesizer,
+    ModelZooCorpus,
+    flatten_state_dict,
+    unflatten_to_state_dict,
+)
+
+
+def test_flatten_roundtrip_preserves_tensors():
+    model = nn.Sequential(nn.Linear(4, 3), nn.LayerNorm(3))
+    state_dict = model.state_dict()
+    flat, metadata = flatten_state_dict(state_dict)
+    reconstructed = unflatten_to_state_dict(flat, metadata)
+
+    for key, tensor in state_dict.items():
+        assert torch.allclose(tensor, reconstructed[key])
+
+
+def _make_toy_state_dict(seed: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(seed)
+    model = nn.Sequential(nn.Linear(6, 8), nn.ReLU(), nn.Linear(8, 4))
+    return model.state_dict()
+
+
+def test_model_zoo_corpus_normalization(tmp_path):
+    files = []
+    for idx in range(3):
+        state_dict = _make_toy_state_dict(idx)
+        path = tmp_path / f"model_{idx}.safetensors"
+        save_file(state_dict, str(path))
+        files.append(path)
+
+    corpus = ModelZooCorpus(files)
+    normalized = torch.stack([corpus[i][0] for i in range(len(corpus))])
+
+    assert normalized.shape == (len(files), corpus.vector_dim)
+    assert torch.allclose(normalized.mean(dim=0), torch.zeros(corpus.vector_dim), atol=1e-5)
+    assert torch.allclose(normalized.std(dim=0, unbiased=False), torch.ones(corpus.vector_dim), atol=1e-5)
+
+    recovered = corpus.denormalize(normalized[0])
+    assert torch.allclose(recovered, corpus.vectors[0])
+
+
+def test_diffusion_synthesizer_sampling(tmp_path):
+    files = []
+    metadata_reference = None
+    for idx in range(2):
+        state_dict = _make_toy_state_dict(idx + 10)
+        path = tmp_path / f"train_{idx}.safetensors"
+        save_file(state_dict, str(path))
+        files.append(path)
+        if metadata_reference is None:
+            _, metadata_reference = flatten_state_dict(state_dict)
+
+    corpus = ModelZooCorpus(files)
+    synthesizer = DiffusionSynthesizer(corpus.vector_dim, timesteps=16)
+
+    batch = torch.stack([corpus[i][0] for i in range(len(corpus))])
+    loss, details = synthesizer.compute_loss(batch)
+
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    assert details["noisy_weights"].shape == batch.shape
+
+    samples = synthesizer.sample(num_samples=3, device=batch.device)
+    assert samples.shape == (3, corpus.vector_dim)
+
+    denormalized = corpus.denormalize(samples[0]).cpu()
+    state_dict = unflatten_to_state_dict(denormalized, metadata_reference)
+    assert set(state_dict.keys()) == {info.key for info in metadata_reference}


### PR DESCRIPTION
## Summary
- implement a diffusion synthesizer that flattens checkpoints, normalizes a static corpus, and denoises weight vectors with a cosine noise schedule
- add unit tests covering state dict flattening, corpus statistics, and diffusion sampling paths

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d14263f3648325ad38cacdb0fd3320