### PR TITLE
Add autoencoder and latent diffusion weight synthesis pipeline

### DIFF
--- a/latent_diffusion.py
+++ b/latent_diffusion.py
@@ -1,0 +1,146 @@
+import math
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+from perceiver_ae import PerceiverAE
+
+
+class TimestepEmbed(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(1, dim)
+        self.act = nn.SiLU()
+        self.fc2 = nn.Linear(dim, dim)
+
+    def forward(self, t_scalar: torch.Tensor) -> torch.Tensor:
+        # t_scalar: [B, 1] in [0, 1]
+        x = self.fc1(t_scalar)
+        x = self.act(x)
+        x = self.fc2(x)
+        return x
+
+
+class LatentDenoiser(nn.Module):
+    """Small MLP denoiser on z. Input: noisy z_t and t → predict ε."""
+
+    def __init__(self, z_dim: int = 512, hidden: int = 1024) -> None:
+        super().__init__()
+        self.tproj = TimestepEmbed(z_dim)
+        self.net = nn.Sequential(
+            nn.Linear(z_dim, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, z_dim),
+        )
+
+    def forward(self, z_noisy: torch.Tensor, t01: torch.Tensor) -> torch.Tensor:
+        h = z_noisy + self.tproj(t01)
+        return self.net(h)
+
+
+class CosineSchedule:
+    """Classic cosine beta schedule utilities."""
+
+    def __init__(self, T: int = 1000) -> None:
+        if T <= 0:
+            raise ValueError("Number of diffusion steps T must be positive")
+        self.T = T
+        s = 0.008
+        steps = torch.arange(T + 1, dtype=torch.float32)
+        alphas_cumprod = torch.cos(((steps / T) + s) / (1 + s) * math.pi * 0.5) ** 2
+        alphas_cumprod = alphas_cumprod / alphas_cumprod[0]
+        self.alphas_bar = alphas_cumprod  # [0..T]
+
+    def to(self, device: torch.device | str) -> "CosineSchedule":
+        self.alphas_bar = self.alphas_bar.to(device)
+        return self
+
+
+def q_sample(
+    z0: torch.Tensor, t: torch.Tensor, sched: CosineSchedule, noise: torch.Tensor | None = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Forward diffusion: z_t = sqrt(alpha_bar_t) z0 + sqrt(1 - alpha_bar_t) * ε."""
+
+    if noise is None:
+        noise = torch.randn_like(z0)
+    a = sched.alphas_bar[t].view(-1, 1)
+    return (a.sqrt() * z0) + ((1 - a).sqrt() * noise), noise
+
+
+@torch.no_grad()
+def ddim_sample(
+    denoiser: nn.Module,
+    sched: CosineSchedule,
+    z_dim: int = 512,
+    steps: int = 50,
+    device: torch.device | str = "cpu",
+) -> torch.Tensor:
+    if steps < 2:
+        raise ValueError("DDIM sampling requires at least two steps")
+
+    device = torch.device(device)
+    # Uniform timesteps mapped onto the scheduler range.
+    t_cont = torch.linspace(0, sched.T - 1, steps, dtype=torch.float32, device=device)
+    t_seq = torch.flip(t_cont.round().long().unique_consecutive(), dims=(0,))
+    if t_seq.numel() < 2:
+        raise RuntimeError("Time sequence collapsed to fewer than two unique steps")
+
+    z = torch.randn(1, z_dim, device=device)
+    for ti, tj in zip(t_seq[:-1], t_seq[1:]):
+        t01 = (ti.float() / sched.T).view(1, 1)
+        eps = denoiser(z, t01)
+        a_t = sched.alphas_bar[ti]
+        a_s = sched.alphas_bar[tj]
+        # DDIM update (η=0)
+        z0 = (z - (1 - a_t).sqrt() * eps) / a_t.sqrt()
+        z = a_s.sqrt() * z0 + (1 - a_s).sqrt() * eps
+    return z
+
+
+def train_latent_diffusion(
+    ae: PerceiverAE,
+    flat_dataset: torch.utils.data.Dataset,
+    epochs: int = 5,
+    batch_size: int = 16,
+    lr: float = 2e-4,
+    T: int = 1000,
+) -> tuple[LatentDenoiser, CosineSchedule]:
+    """Train a diffusion model in the autoencoder's latent space."""
+
+    device = next(ae.parameters()).device
+    ae.eval()
+    dl = torch.utils.data.DataLoader(flat_dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+    sched = CosineSchedule(T=T).to(device)
+    denoiser = LatentDenoiser(z_dim=ae.latent_dim).to(device)
+    opt = torch.optim.AdamW(denoiser.parameters(), lr=lr)
+    mse = nn.MSELoss()
+
+    for epoch in range(epochs):
+        total = 0.0
+        for x in dl:
+            x = x.to(device)
+            with torch.no_grad():
+                z0 = ae.encode(x)  # [B, z_dim]
+            t = torch.randint(low=0, high=T, size=(x.size(0),), device=device)
+            zt, eps = q_sample(z0, t, sched)
+            t01 = (t.float() / T).view(-1, 1)
+            eps_hat = denoiser(zt, t01)
+            loss = mse(eps_hat, eps)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            total += loss.item()
+        print(f"[LD] epoch {epoch} | eps MSE {total/len(dl):.6f}")
+
+    return denoiser, sched
+
+
+@torch.no_grad()
+def generate_weights(ae: PerceiverAE, denoiser: LatentDenoiser, sched: CosineSchedule) -> torch.Tensor:
+    device = next(ae.parameters()).device
+    z = ddim_sample(denoiser, sched, z_dim=ae.latent_dim, device=device)
+    x_hat = ae.decode(z)
+    return x_hat.squeeze(0)

--- a/perceiver_ae.py
+++ b/perceiver_ae.py
@@ -1,0 +1,117 @@
+import math
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class PerceiverBlock(nn.Module):
+    """Single Perceiver-style block with cross- and self-attention."""
+
+    def __init__(self, latent_dim: int, num_heads: int = 8, ff_mult: int = 4, dropout: float = 0.0):
+        super().__init__()
+        self.cross_attn = nn.MultiheadAttention(latent_dim, num_heads, batch_first=True)
+        self.cross_norm = nn.LayerNorm(latent_dim)
+        self.self_attn = nn.MultiheadAttention(latent_dim, num_heads, batch_first=True)
+        self.self_norm = nn.LayerNorm(latent_dim)
+        self.ff = nn.Sequential(
+            nn.LayerNorm(latent_dim),
+            nn.Linear(latent_dim, ff_mult * latent_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(ff_mult * latent_dim, latent_dim),
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, latents: torch.Tensor, tokens: torch.Tensor) -> torch.Tensor:
+        # Cross-attention: latents query the input tokens.
+        cross, _ = self.cross_attn(latents, tokens, tokens, need_weights=False)
+        latents = self.cross_norm(latents + self.dropout(cross))
+
+        # Self-attention on the latent array.
+        self_out, _ = self.self_attn(latents, latents, latents, need_weights=False)
+        latents = self.self_norm(latents + self.dropout(self_out))
+
+        # Feed-forward network.
+        latents = latents + self.dropout(self.ff(latents))
+        return latents
+
+
+class PerceiverAE(nn.Module):
+    """Autoencoder that compresses a flat parameter vector into a Perceiver latent."""
+
+    def __init__(
+        self,
+        D: int,
+        num_latents: int = 64,
+        latent_dim: int = 512,
+        depth: int = 6,
+        num_heads: int = 8,
+        ff_mult: int = 4,
+        chunk_size: int | None = None,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if D <= 0:
+            raise ValueError("Input dimension D must be positive")
+
+        if chunk_size is None:
+            chunk_size = max(1, math.ceil(D / num_latents))
+        self.chunk_size = int(chunk_size)
+        self.num_chunks = math.ceil(D / self.chunk_size)
+        self.padded_dim = self.num_chunks * self.chunk_size
+
+        self.D = int(D)
+        self.latent_dim = int(latent_dim)
+        self.num_latents = int(num_latents)
+
+        self.input_proj = nn.Linear(self.chunk_size, latent_dim)
+        self.latent_array = nn.Parameter(torch.randn(num_latents, latent_dim) * 0.02)
+        self.blocks = nn.ModuleList(
+            [PerceiverBlock(latent_dim, num_heads=num_heads, ff_mult=ff_mult, dropout=dropout) for _ in range(depth)]
+        )
+        self.to_latent = nn.Sequential(nn.LayerNorm(latent_dim), nn.Linear(latent_dim, latent_dim))
+
+        self.decoder_latents = nn.Sequential(
+            nn.LayerNorm(latent_dim),
+            nn.Linear(latent_dim, self.num_chunks * latent_dim),
+            nn.GELU(),
+        )
+        self.chunk_out = nn.Linear(latent_dim, self.chunk_size)
+
+    def _pad(self, x: torch.Tensor) -> torch.Tensor:
+        if x.shape[-1] == self.padded_dim:
+            return x
+        pad = self.padded_dim - x.shape[-1]
+        return F.pad(x, (0, pad))
+
+    def _tokenize(self, x: torch.Tensor) -> torch.Tensor:
+        x = self._pad(x)
+        b = x.shape[0]
+        tokens = x.view(b, self.num_chunks, self.chunk_size)
+        tokens = self.input_proj(tokens)
+        return tokens
+
+    def _latent_template(self, batch_size: int) -> torch.Tensor:
+        return self.latent_array.unsqueeze(0).expand(batch_size, -1, -1)
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        tokens = self._tokenize(x)
+        latents = self._latent_template(tokens.shape[0])
+        for block in self.blocks:
+            latents = block(latents, tokens)
+        latents = latents.mean(dim=1)
+        return self.to_latent(latents)
+
+    def decode(self, z: torch.Tensor) -> torch.Tensor:
+        latent_tokens = self.decoder_latents(z)
+        latent_tokens = latent_tokens.view(z.shape[0], self.num_chunks, self.latent_dim)
+        chunks = self.chunk_out(latent_tokens)
+        recon = chunks.view(z.shape[0], -1)[..., : self.D]
+        return recon
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        z = self.encode(x)
+        recon = self.decode(z)
+        return recon, z

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,41 @@
+from train_ae import FlatWeightsDataset, train_autoencoder
+from latent_diffusion import train_latent_diffusion, generate_weights
+
+
+def run_training_pipeline(
+    data_dir: str,
+    ae_epochs: int = 5,
+    ae_batch_size: int = 2,
+    ae_lr: float = 1e-4,
+    num_latents: int = 64,
+    latent_dim: int = 512,
+    depth: int = 6,
+    diff_epochs: int = 10,
+    diff_batch_size: int = 32,
+    diff_lr: float = 2e-4,
+    diff_T: int = 1000,
+):
+    ae = train_autoencoder(
+        data_dir,
+        epochs=ae_epochs,
+        batch_size=ae_batch_size,
+        lr=ae_lr,
+        num_latents=num_latents,
+        latent_dim=latent_dim,
+        depth=depth,
+    )
+    dataset = FlatWeightsDataset(data_dir)
+    denoiser, sched = train_latent_diffusion(
+        ae,
+        dataset,
+        epochs=diff_epochs,
+        batch_size=diff_batch_size,
+        lr=diff_lr,
+        T=diff_T,
+    )
+    flat_weights = generate_weights(ae, denoiser, sched)
+    return flat_weights, ae, denoiser, sched
+
+
+if __name__ == "__main__":
+    raise SystemExit("This module provides run_training_pipeline() for scripted use.")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,43 @@
+import torch
+from safetensors.torch import save_file
+
+from latent_diffusion import generate_weights, train_latent_diffusion
+from train_ae import FlatWeightsDataset, train_autoencoder
+
+
+def _create_dummy_dataset(dir_path, num_files: int = 4) -> str:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    for idx in range(num_files):
+        weights = {
+            "layer.weight": torch.randn(4, 3),
+            "layer.bias": torch.randn(4),
+        }
+        save_file(weights, str(dir_path / f"sample_{idx}.safetensors"))
+    return str(dir_path)
+
+
+def test_end_to_end_pipeline(tmp_path):
+    data_dir = _create_dummy_dataset(tmp_path / "weights")
+    ae = train_autoencoder(
+        data_dir,
+        epochs=1,
+        batch_size=2,
+        lr=1e-3,
+        num_latents=4,
+        latent_dim=16,
+        depth=1,
+    )
+
+    dataset = FlatWeightsDataset(data_dir)
+    denoiser, sched = train_latent_diffusion(
+        ae,
+        dataset,
+        epochs=1,
+        batch_size=2,
+        lr=1e-3,
+        T=10,
+    )
+
+    flat_weights = generate_weights(ae, denoiser, sched)
+    assert flat_weights.shape[0] == dataset.D
+    assert torch.isfinite(flat_weights).all()

--- a/train_ae.py
+++ b/train_ae.py
@@ -1,0 +1,78 @@
+import glob
+import os
+from typing import List
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset
+from safetensors.torch import load_file
+
+from perceiver_ae import PerceiverAE
+
+
+def flatten_state_dict(state_dict: dict[str, torch.Tensor]) -> torch.Tensor:
+    """Flatten a state dict into a single vector with a deterministic key order."""
+
+    flat_parts: List[torch.Tensor] = []
+    for key in sorted(state_dict.keys()):
+        flat_parts.append(state_dict[key].reshape(-1))
+    return torch.cat(flat_parts, dim=0)
+
+
+class FlatWeightsDataset(Dataset):
+    def __init__(self, dir_with_safetensors: str) -> None:
+        paths = sorted(glob.glob(os.path.join(dir_with_safetensors, "*.safetensors")))
+        if not paths:
+            raise FileNotFoundError(f"No .safetensors in {dir_with_safetensors}")
+        self.paths = paths
+
+        sample = load_file(self.paths[0])
+        self.D = sum(param.numel() for param in sample.values())
+
+    def __len__(self) -> int:
+        return len(self.paths)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        sd = load_file(self.paths[idx])
+        x = flatten_state_dict(sd).float()
+        return x
+
+
+def train_autoencoder(
+    data_dir: str,
+    epochs: int = 5,
+    batch_size: int = 2,
+    lr: float = 1e-4,
+    num_latents: int = 64,
+    latent_dim: int = 512,
+    depth: int = 6,
+    device: torch.device | None = None,
+) -> PerceiverAE:
+    dataset = FlatWeightsDataset(data_dir)
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+
+    ae = PerceiverAE(D=dataset.D, num_latents=num_latents, latent_dim=latent_dim, depth=depth)
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ae = ae.to(device)
+
+    opt = torch.optim.AdamW(ae.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    for epoch in range(epochs):
+        ae.train()
+        total = 0.0
+        for batch in dataloader:
+            batch = batch.to(device)
+            recon, _ = ae(batch)
+            loss = loss_fn(recon, batch)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            total += loss.item()
+        print(f"[AE] epoch {epoch} | loss {total / len(dataloader):.6f}")
+
+    return ae
+
+
+__all__ = ["FlatWeightsDataset", "train_autoencoder", "flatten_state_dict"]


### PR DESCRIPTION
## Summary
- add a Perceiver-style autoencoder and flat weight dataset utilities for safetensor checkpoints
- implement latent diffusion training and sampling over the autoencoder latent space with a runnable pipeline helper
- cover the pipeline with a synthetic safetensor integration test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68d9a47eb5708325b3106d0cd055d9bb