### PR TITLE
Fix dataloader drop_last handling for small datasets

### DIFF
--- a/diffusion_optimizer.py
+++ b/diffusion_optimizer.py
@@ -187,7 +187,8 @@ class WeightDiffusionMLP(nn.Module):
 
 
 def _prepare_dataloader(dataset: ModelZooDataset, batch_size: int) -> DataLoader:
-    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=len(dataset) > 1)
+    drop_last = len(dataset) >= batch_size and batch_size > 0
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=drop_last)
 
 
 def train_synthesizer(


### PR DESCRIPTION
## Summary
- conditionally enable drop_last when the dataset has at least one full batch
- allow training to proceed even when the batch size exceeds the dataset length

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4cb630b148325988298944c37df1b