### PR TITLE
Follow-up: adjust dataloader drop_last handling

### DIFF
--- a/diffusion_optimizer.py
+++ b/diffusion_optimizer.py
@@ -187,7 +187,8 @@ class WeightDiffusionMLP(nn.Module):
 
 
 def _prepare_dataloader(dataset: ModelZooDataset, batch_size: int) -> DataLoader:
-    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=len(dataset) > 1)
+    drop_last = len(dataset) >= batch_size
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=drop_last)
 
 
 def train_synthesizer(


### PR DESCRIPTION
## Summary
- update dataloader construction to avoid dropping datasets smaller than the batch size

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c5d9a4008325b194c2f743589ef2)