### PR TITLE
Fix DataLoader drop_last for small datasets; add regression test for oversized batches

### DIFF
--- a/tests/test_diffusion_optimizer.py
+++ b/tests/test_diffusion_optimizer.py
@@ -97,3 +97,24 @@ def test_training_and_generation(tmp_path):
     spectra = compute_spectral_properties(generated[0])
     for values in spectra.values():
         assert values.min().item() >= -1e-5
+
+
+def test_training_uses_dataset_smaller_than_batch_size(tmp_path):
+    paths = _write_corpus(tmp_path, count=2)
+    dataset = ModelZooDataset(paths)
+    schedule = DiffusionSchedule(timesteps=2)
+    model = WeightDiffusionMLP(
+        parameter_dim=dataset.feature_dim,
+        bottleneck_dim=16,
+    )
+
+    losses = train_synthesizer(
+        model,
+        dataset,
+        schedule,
+        epochs=2,
+        batch_size=len(dataset) + 1,
+        lr=1e-3,
+    )
+
+    assert len(losses) == 2


### PR DESCRIPTION
### Motivation
- The dataloader was configured as `drop_last=len(dataset) > 1`, which can drop the only batch when `batch_size > len(dataset)` and result in zero training steps without warning. 

### Description
- Change `_prepare_dataloader` to `drop_last = len(dataset) >= batch_size` so partial batches are retained when the dataset is smaller than the requested `batch_size`.
- Add `test_training_uses_dataset_smaller_than_batch_size` to `tests/test_diffusion_optimizer.py` which trains for two epochs with `batch_size = len(dataset) + 1` and asserts two recorded losses.

### Testing
- `python -m py_compile diffusion_optimizer.py tests/test_diffusion_optimizer.py` succeeded. 
- `pytest` was attempted but test collection failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'torch'`), so end-to-end test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f534aa1848325a00b5424eeba3ad3)